### PR TITLE
Add simple Terraform file with security issues for testing

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -131,4 +131,4 @@ def login():
 
 if __name__ == '__main__':
     # Development server - not suitable for production
-    app.run(debug=True, host='0.0.0.0', port=5000)  # Security issue: debug mode in production 
+    app.run(debug=True, host='0.0.0.0', port=5000)  # Security issue: debug mode in production # Small PR test

--- a/python/app.py
+++ b/python/app.py
@@ -132,3 +132,4 @@ def login():
 if __name__ == '__main__':
     # Development server - not suitable for production
     app.run(debug=True, host='0.0.0.0', port=5000)  # Security issue: debug mode in production # Small PR test
+# Tiny PR test

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -120,3 +120,6 @@ output "vpc_id" {
 output "instance_id" {
   value = aws_instance.web.id
 } 
+module "external_example" {
+  source = "git::https://github.com/hashicorp/terraform-aws-consul.git"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -112,6 +112,15 @@ resource "aws_iam_role_policy" "lambda_policy" {
   })
 }
 
+# Test Module with Security Issues
+module "test_module" {
+  source = "./modules/test-module"
+  
+  environment  = "test"
+  project_name = "security-test"
+  region       = "us-west-2"
+}
+
 # Output values
 output "vpc_id" {
   value = aws_vpc.main.id
@@ -119,7 +128,14 @@ output "vpc_id" {
 
 output "instance_id" {
   value = aws_instance.web.id
-} 
-module "external_example" {
-  source = "git::https://github.com/hashicorp/terraform-aws-consul.git"
+}
+
+output "test_module_instance_id" {
+  description = "Instance ID from test module"
+  value       = module.test_module.instance_id
+}
+
+output "test_module_bucket_name" {
+  description = "Bucket name from test module"
+  value       = module.test_module.bucket_name
 }

--- a/terraform/modules/test-module/main.tf
+++ b/terraform/modules/test-module/main.tf
@@ -1,0 +1,114 @@
+# Test Terraform Module with Security Issues
+# This module is intentionally written with security vulnerabilities for testing
+
+# Security Issue 1: Hardcoded credentials
+variable "aws_access_key" {
+  description = "AWS Access Key"
+  type        = string
+  default     = "AKIAIOSFODNN7EXAMPLE"  # Hardcoded credentials - SECURITY ISSUE
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+  type        = string
+  default     = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # Hardcoded credentials - SECURITY ISSUE
+}
+
+# Security Issue 2: Overly permissive security group
+resource "aws_security_group" "test_sg" {
+  name        = "test-security-group"
+  description = "Test security group with overly permissive rules"
+
+  # SECURITY ISSUE: Allowing all traffic from anywhere
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # SECURITY ISSUE: Too permissive
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # SECURITY ISSUE: Too permissive
+  }
+
+  tags = {
+    Name = "test-security-group"
+  }
+}
+
+# Security Issue 3: Instance without encryption
+resource "aws_instance" "test_instance" {
+  ami           = "ami-12345678"  # SECURITY ISSUE: Hardcoded AMI
+  instance_type = "t2.micro"
+
+  # SECURITY ISSUE: No encryption at rest
+  root_block_device {
+    volume_size = 20
+    # Missing encryption = true
+  }
+
+  # SECURITY ISSUE: Using default security group
+  vpc_security_group_ids = [aws_security_group.test_sg.id]
+
+  # SECURITY ISSUE: No user data encryption
+  user_data = base64encode(<<-EOF
+              #!/bin/bash
+              echo "root:password123" | chpasswd  # SECURITY ISSUE: Hardcoded password
+              EOF
+  )
+
+  tags = {
+    Name = "test-instance"
+  }
+}
+
+# Security Issue 4: S3 bucket without encryption
+resource "aws_s3_bucket" "test_bucket" {
+  bucket = "my-test-bucket-${random_string.bucket_suffix.result}"
+
+  # SECURITY ISSUE: No encryption configuration
+  # SECURITY ISSUE: No versioning
+  # SECURITY ISSUE: No access logging
+}
+
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Security Issue 5: IAM policy that's too permissive
+resource "aws_iam_policy" "test_policy" {
+  name        = "test-policy"
+  description = "Test IAM policy with overly permissive permissions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "*"  # SECURITY ISSUE: Wildcard permissions
+        Resource = "*"  # SECURITY ISSUE: Wildcard resources
+      }
+    ]
+  })
+}
+
+# Outputs
+output "instance_id" {
+  description = "ID of the created instance"
+  value       = aws_instance.test_instance.id
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.test_sg.id
+}
+
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.test_bucket.bucket
+} 

--- a/terraform/modules/test-module/outputs.tf
+++ b/terraform/modules/test-module/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "ID of the created instance"
+  value       = aws_instance.test_instance.id
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.test_sg.id
+}
+
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.test_bucket.bucket
+}
+
+output "iam_policy_arn" {
+  description = "ARN of the IAM policy"
+  value       = aws_iam_policy.test_policy.arn
+} 

--- a/terraform/modules/test-module/variables.tf
+++ b/terraform/modules/test-module/variables.tf
@@ -1,0 +1,17 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "test"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "test-project"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+} 

--- a/terraform/simple_security_test.tf
+++ b/terraform/simple_security_test.tf
@@ -1,0 +1,54 @@
+# Simple Terraform file with obvious security issues for testing
+
+# SECURITY ISSUE 1: Hardcoded credentials
+variable "aws_access_key" {
+  description = "AWS Access Key"
+  type        = string
+  default     = "AKIAIOSFODNN7EXAMPLE"  # SECURITY ISSUE: Hardcoded credentials
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+  type        = string
+  default     = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # SECURITY ISSUE: Hardcoded credentials
+}
+
+# SECURITY ISSUE 2: Overly permissive security group
+resource "aws_security_group" "test_sg" {
+  name        = "test-security-group"
+  description = "Test security group with overly permissive rules"
+
+  # SECURITY ISSUE: Allowing all traffic from anywhere
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # SECURITY ISSUE: Too permissive
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # SECURITY ISSUE: Too permissive
+  }
+}
+
+# SECURITY ISSUE 3: Instance without encryption
+resource "aws_instance" "test_instance" {
+  ami           = "ami-12345678"  # SECURITY ISSUE: Hardcoded AMI
+  instance_type = "t2.micro"
+
+  # SECURITY ISSUE: No encryption at rest
+  root_block_device {
+    volume_size = 20
+    # Missing encryption = true
+  }
+
+  # SECURITY ISSUE: Hardcoded password in user data
+  user_data = base64encode(<<-EOF
+              #!/bin/bash
+              echo "root:password123" | chpasswd  # SECURITY ISSUE: Hardcoded password
+              EOF
+  )
+} 


### PR DESCRIPTION
This PR adds a simple Terraform file with obvious security issues to test the agent's ability to detect and comment on specific line-by-line security problems. Issues include: - Hardcoded AWS credentials - Overly permissive security groups - Unencrypted resources - Hardcoded passwords